### PR TITLE
docs: add CONTRIBUTING.md guide for local development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,158 @@
+# Contributing to Salt Cellar Map
+
+Thanks for your interest in contributing! This guide will get you from zero to a running local environment.
+
+## Prerequisites
+
+- **[Bun](https://bun.sh/)** ≥ 1.x — used for the runtime, package manager, and test runner
+- **[Docker](https://docs.docker.com/get-docker/) + Docker Compose** — used to run PostgreSQL locally
+- **A Discord application** — required for OAuth login to work (see [Discord Setup](#discord-setup) below)
+- **A Google Maps API key** — required to load the map and search places
+
+## Local Development
+
+There are two ways to run the app locally. **Option A is recommended** for active development because hot-reload is faster and you can run tests directly.
+
+### Option A — Native Bun + Docker DB
+
+This runs the SvelteKit dev server on your machine and only containerises the database.
+
+```sh
+# 1. Clone and install dependencies
+git clone <repo-url>
+cd sc-map
+bun install
+
+# 2. Set up environment
+cp .env.example .env
+# Edit .env — see "Environment Variables" below
+
+# 3. Start the database
+docker compose -f docker-compose.dev.yml up -d
+
+# 4. Run database migrations
+bun run migrate
+
+# 5. Start the dev server
+bun run dev
+# → http://localhost:5173
+```
+
+### Option B — Full Docker Stack
+
+This builds and runs the entire application (app + database) in Docker, closest to how it runs in production.
+
+```sh
+# 1. Clone
+git clone <repo-url>
+cd sc-map
+
+# 2. Set up environment
+cp .env.example .env
+# Edit .env — see "Environment Variables" below
+
+# 3. Build and start everything
+docker compose -f docker-compose.local.yml up --build
+# → http://localhost:3000
+```
+
+> Migrations run automatically on container startup via `docker-entrypoint.sh`.
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in each value:
+
+| Variable | Description |
+|---|---|
+| `PUBLIC_GOOGLE_MAPS_API_KEY` | Google Maps JS API key |
+| `PUBLIC_DISCORD_CLIENT_ID` | Discord OAuth app client ID |
+| `SESSION_SECRET` | Long random string, e.g. `openssl rand -hex 32` |
+| `DISCORD_CLIENT_SECRET` | Discord OAuth app secret |
+| `DISCORD_REDIRECT_URI` | OAuth callback URL (see below) |
+| `DISCORD_GUILD_ID` | Your Discord server's ID |
+| `DISCORD_GOATED_ROLE_ID` | Role ID for permanent access tier |
+| `ORIGIN` | Full URL the app is served from |
+
+For **Option A**, set:
+```
+DISCORD_REDIRECT_URI=http://localhost:5173/auth/discord/callback
+ORIGIN=http://localhost:5173
+```
+
+For **Option B**, set:
+```
+DISCORD_REDIRECT_URI=http://localhost:3000/auth/discord/callback
+ORIGIN=http://localhost:3000
+```
+
+> `PUBLIC_*` variables are baked into the client bundle at **build time**. If you change them, you must rebuild (`bun run build` or `docker compose build`).
+
+## Discord Setup
+
+You need a Discord application to use OAuth login:
+
+1. Go to the [Discord Developer Portal](https://discord.com/developers/applications) and create a new application.
+2. Under **OAuth2 → Redirects**, add your callback URL (e.g. `http://localhost:5173/auth/discord/callback`).
+3. Copy the **Client ID** and **Client Secret** into `.env`.
+4. Set `DISCORD_GUILD_ID` to the ID of the Discord server you want to gate access to.
+5. Set `DISCORD_GOATED_ROLE_ID` to a role ID for the elevated access tier (or any role if you don't need tiered access).
+
+## Running Tests
+
+```sh
+bun run test               # unit tests — fast, no DB required
+bun run test:integration   # integration tests — uses a real sc_map_test database
+```
+
+Unit tests mock the database layer via `src/lib/dao/mock.ts`. Integration tests connect to a real database; the test script handles setup automatically.
+
+To run a single test file:
+
+```sh
+bun test src/lib/dao/places/index.test.ts
+```
+
+## Code Standards
+
+All code must pass lint and formatting checks with **zero warnings**:
+
+```sh
+bun run lint     # check
+bun run format   # auto-fix
+```
+
+Key rules (enforced by pre-commit hooks via `prek`):
+
+- **TypeScript**: no `any`, no unused variables, strict mode
+- **Synchronous functions** must return `Result<T, E>` (see `src/lib/result.ts`) instead of throwing
+- **Asynchronous functions** may throw
+- Every database migration `.up.sql` file must have a corresponding `.down.sql` file
+
+## Making a PR
+
+1. Branch from `staging`:
+   ```sh
+   git checkout staging && git pull
+   git checkout -b your-feature-name
+   ```
+2. Make your changes and ensure `bun run lint` passes.
+3. If you're adding or changing database schema, create a migration:
+   ```
+   src/lib/db/migrations/<timestamp>_description.up.sql
+   src/lib/db/migrations/<timestamp>_description.down.sql
+   ```
+4. Open a pull request against `staging` with a clear description of what changed and why.
+
+## Project Structure
+
+```
+src/
+├── lib/
+│   ├── dao/          # Data access objects (SQL queries, Zod-validated types)
+│   ├── db/           # DB singleton, migrations
+│   ├── server/       # Server-only utilities (auth, OAuth, Places API)
+│   └── result.ts     # Result<T, E> type for synchronous error handling
+└── routes/           # SvelteKit pages and API endpoints
+```
+
+See [DESIGN_DOC.md](./DESIGN_DOC.md) for the full architecture and data model.

--- a/README.md
+++ b/README.md
@@ -1,42 +1,69 @@
-# sv
+# Salt Cellar Map
 
-Everything you need to build a Svelte project, powered by [`sv`](https://github.com/sveltejs/cli).
+A Discord-gated web app for Salt Cellar members to discover, submit, and review food & drink venues on an interactive map.
 
-## Creating a project
+Access is tied to Discord guild membership. Members can browse and submit places; "Goated" role holders get permanent lifetime access.
 
-If you're seeing this, you've probably already done this step. Congrats!
+## Tech Stack
 
-```sh
-# create a new project
-npx sv create my-app
-```
+- **Framework**: SvelteKit (SSR + API routes)
+- **Runtime**: Bun
+- **Database**: PostgreSQL 17
+- **Auth**: Discord OAuth with HMAC-signed session cookies
+- **Reverse proxy**: nginx (Docker) / Traefik (production)
 
-To recreate this project with the same configuration:
+## Quick Start
 
-```sh
-# recreate this project
-bun x sv@0.12.7 create --template minimal --types ts --add prettier eslint --install bun .
-```
-
-## Developing
-
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+### Option A — Native Bun (recommended for development)
 
 ```sh
-npm run dev
-
-# or start the server and open the app in a new browser tab
-npm run dev -- --open
+git clone <repo-url> && cd sc-map
+bun install
+cp .env.example .env   # fill in your secrets
+docker compose -f docker-compose.dev.yml up -d   # start Postgres only
+bun run migrate
+bun run dev              # http://localhost:5173
 ```
 
-## Building
-
-To create a production version of your app:
+### Option B — Full Docker stack
 
 ```sh
-npm run build
+cp .env.example .env   # fill in your secrets
+docker compose -f docker-compose.local.yml up --build
+# app available at http://localhost:3000
 ```
 
-You can preview the production build with `npm run preview`.
+## Environment Variables
 
-> To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+Copy `.env.example` to `.env` and fill in every value before running. Required variables:
+
+| Variable | Description |
+|---|---|
+| `PUBLIC_GOOGLE_MAPS_API_KEY` | Google Maps JS API key (baked into client bundle at build time) |
+| `PUBLIC_DISCORD_CLIENT_ID` | Discord OAuth application client ID |
+| `SESSION_SECRET` | Long random string for HMAC cookie signing |
+| `DISCORD_CLIENT_SECRET` | Discord OAuth secret |
+| `DISCORD_REDIRECT_URI` | OAuth callback URL (e.g. `http://localhost:5173/auth/discord/callback`) |
+| `DISCORD_GUILD_ID` | Your Discord server ID |
+| `DISCORD_GOATED_ROLE_ID` | Role ID that grants permanent access |
+| `ORIGIN` | Full origin URL the app is served from (e.g. `http://localhost:5173`) |
+
+> `PUBLIC_*` variables are baked into the client bundle at build time — set them before running `docker compose build` or `bun run build`.
+
+## Commands
+
+```sh
+bun run dev               # dev server on :5173
+bun run build             # production build → build/
+bun run migrate           # run pending DB migrations
+bun run test              # unit tests
+bun run test:integration  # integration tests (requires real DB)
+bun run lint              # prettier + eslint check
+bun run format            # auto-format
+```
+
+## Documentation
+
+- [CONTRIBUTING.md](./CONTRIBUTING.md) — how to set up a local environment and contribute
+- [DESIGN_DOC.md](./DESIGN_DOC.md) — architecture decisions and data model
+- [AGENTS.md](./AGENTS.md) — tooling list and code quality rules

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,48 @@
+networks:
+  internal:
+
+services:
+  db:
+    image: postgres:17
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: sc_map
+      POSTGRES_PASSWORD: sc_map
+      POSTGRES_DB: sc_map
+    volumes:
+      - db_data:/var/lib/postgresql/data
+      - ./scripts/init-db.sh:/docker-entrypoint-initdb.d/init-db.sh
+    networks:
+      - internal
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U sc_map -d sc_map']
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  app:
+    build:
+      context: .
+      args:
+        PUBLIC_GOOGLE_MAPS_API_KEY: ${PUBLIC_GOOGLE_MAPS_API_KEY}
+        PUBLIC_DISCORD_CLIENT_ID: ${PUBLIC_DISCORD_CLIENT_ID}
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - '3000:3000'
+    networks:
+      - internal
+    environment:
+      SQL_URL: postgres://sc_map:sc_map@db:5432/sc_map
+      ORIGIN: ${ORIGIN}
+      PUBLIC_GOOGLE_MAPS_API_KEY: ${PUBLIC_GOOGLE_MAPS_API_KEY}
+      SESSION_SECRET: ${SESSION_SECRET}
+      DISCORD_CLIENT_SECRET: ${DISCORD_CLIENT_SECRET}
+      DISCORD_REDIRECT_URI: ${DISCORD_REDIRECT_URI}
+      DISCORD_GUILD_ID: ${DISCORD_GUILD_ID}
+      DISCORD_GOATED_ROLE_ID: ${DISCORD_GOATED_ROLE_ID}
+
+volumes:
+  db_data:


### PR DESCRIPTION
Add a comprehensive contributing guide to assist new developers in setting up the project locally. The guide includes instructions for:
- Prerequisites (Bun, Docker, API keys)
- Local development workflows (native Bun vs. full Docker stack)
- Environment variable configuration and Discord OAuth setup
- Testing commands and code standards
- Pull request creation guidelines

This addition ensures a smoother and standardized onboarding process for open-source contributors.