### PR TITLE
fix: Increase chip inline padding for better mobile spacing

### DIFF
--- a/src/lib/styles/tokens/components/chip.css
+++ b/src/lib/styles/tokens/components/chip.css
@@ -56,7 +56,7 @@
 	--md-comp-chip-height: 32px;
 	--md-comp-chip-shape: var(--md-sys-shape-corner-small); /* 8px */
 	--md-comp-chip-icon-size: 18px;
-	--md-comp-chip-padding-inline: 8px; /* label ↔ edge (no icon) */
+	--md-comp-chip-padding-inline: 16px; /* label ↔ edge (no icon) */
 	--md-comp-chip-icon-gap: 8px; /* gap between icon and label */
 	--md-comp-chip-icon-padding: 8px; /* icon ↔ chip edge */
 


### PR DESCRIPTION
## Summary

Increase `--md-comp-chip-padding-inline` from `8px` to `16px` to give selected category chips more breathing room on mobile, where the dialog is narrow and chips appear cramped.

Resolves https://github.com/SaltCellar-FOSS/sc-map/issues/14

## ⚠️ Testing Note

Not tested end-to-end (no running environment available). Build, lint, and unit tests pass. Please pull and test locally before merging.