### PR TITLE
Dark mode

### DIFF
--- a/src/lib/components/PlaceMap.svelte
+++ b/src/lib/components/PlaceMap.svelte
@@ -180,6 +180,7 @@
 			center: DEFAULT_MAP_CENTER,
 			zoom: DEFAULT_MAP_ZOOM,
 			mapId: MAP_ID,
+			colorScheme: google.maps.ColorScheme.FOLLOW_SYSTEM,
 			mapTypeControl: false,
 			streetViewControl: false,
 			fullscreenControl: false


### PR DESCRIPTION
## Summary

- Adds Google Maps dark mode support via `colorScheme: FOLLOW_SYSTEM`

🤖 Generated with [Claude Code](https://claude.com/claude-code)